### PR TITLE
Code Consistency Improvements and Fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,8 @@
+##################################################
+#  PML Reference Manual:                         #
+#  https://github.com/pml-lang/reference-manual  #
+##################################################
+
 root = true
 
 ## Repository Configurations
@@ -10,9 +15,57 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[.gitmodules]
+indent_style = tab
+
+
+## Markdown GFM
+###############
+[*.md]
+indent_style = space
+indent_size = unset
+end_of_line = unset
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+## Shell Scripts
+################
+[*.sh]
+end_of_line = lf
+indent_style = tab
+indent_size = unset
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+## Batch Scripts
+################
+[*.bat]
+indent_style = tab
+indent_size = unset
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
 ## PML Markup
 #############
 [*.pml]
+indent_style = space
+indent_size = 4
+end_of_line = unset
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+## PPL Sources
+##############
+[*.ppl]
 indent_style = space
 indent_size = 4
 end_of_line = unset

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+##################################################
+#  PML Reference Manual:                         #
+#  https://github.com/pml-lang/reference-manual  #
+##################################################
+
+* text=auto
+
+## Repository Configuration
+###########################
+.editorconfig    text eol=lf
+.gitlab-ci.yml   text eol=lf
+.travis.yml      text eol=lf
+.gitattributes   text eol=lf
+.gitconfig       text eol=lf
+.gitignore       text eol=lf
+.gitmodules      text eol=lf
+
+
+## Documentation Files
+######################
+*.pml     text
+*.md      text
+*.txt     text
+LICENSE   text
+
+
+## Scripts
+##########
+*.sh    text eol=lf
+*.bat   text eol=crlf
+
+
+## Miscellanea
+##############
+*.ppl   text

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,110 @@
+##################################################
+#  PML Reference Manual:                         #
+#  https://github.com/pml-lang/reference-manual  #
+##################################################
+
 /bin
 /output
 /temp
+
+*.html
 
 # Directories and files starting with ---
 **/---*
 
 # Directories and files starting with NOGIT_
 **/NOGIT_*
+
+
+## Misc Work Files
+##################
+
+# Temporary/backup or removed files and folders:
+___*
+___*.*
+
+# Links and URLs
+*.lnk
+*.url
+
+
+## Apps Local Settings & Temp Files
+###################################
+
+# Chrome's debug logs for local HTML pages:
+debug.log
+
+
+############################
+## COMMON IGNORE PATTERNS ##
+############################
+# Based on ".gitignore" created by:
+# https://www.gitignore.io/api/windows,linux,macos
+
+## Linux
+########
+
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+## macOS
+########
+
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+## Windows
+##########
+
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# End of https://www.gitignore.io/api/windows,linux,macos,purebasic

--- a/README.md
+++ b/README.md
@@ -1,21 +1,39 @@
 # PML Reference Manual
 
-This repository contains the PML markup code used to create the [PML Reference Manual](https://www.pml-lang.dev/docs/reference_manual/index.html).
+This repository contains the PML markup code used to create the _[PML Reference Manual]_.
+
 
 ## Note
 
-The PML code in this repository has been created automatically by the _PML-Converter_'s `create_reference_manual` command. The text is extracted from the converter's [PPL source code](https://github.com/pml-lang/converter). This repository has been published to enable people to submit pull requests and start discussions regarding the reference manual.
+The PML code in this repository has been created automatically by the _PML-Converter_'s `create_reference_manual` command.
+The text is extracted from the converter's [PPL source code].
+This repository has been published to enable people to submit pull requests and start discussions regarding the reference manual.
+
 
 ## Create an HTML version
 
 You can create an HTML version of the reference manual like this:
-- If not done already, [install](https://www.pml-lang.dev/downloads/install.html) the _PML-Converter_
+
+- If not done already, [install the _PML-Converter_]
 - Create a local copy of this repository
 - Open a terminal in the root directory of your local repository
 - Execute the following OS command:
+    ```
+    pmlc convert --input_file input/text/index.pml
+    ```
 
-  `pmlc convert --input_file input/text/index.pml`
 
 ## More info
 
-For more information about PML please visit its [website](https://www.pml-lang.dev).
+For more information about PML, please visit its [website].
+
+<!-----------------------------------------------------------------------------
+                               REFERENCE LINKS
+------------------------------------------------------------------------------>
+
+[install the _PML-Converter_]: https://www.pml-lang.dev/downloads/install.html "Go to the PML Converter download page"
+[PML Reference Manual]: https://www.pml-lang.dev/docs/reference_manual/index.html
+[PPL source code]: https://github.com/pml-lang/converter "Visit the PML Converter source repository on GitHub"
+[website]: https://www.pml-lang.dev "Visit the PML website"
+
+<!-- EOF -->

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can create an HTML version of the reference manual like this:
 - Create a local copy of this repository
 - Open a terminal in the root directory of your local repository
 - Execute the following OS command:
-  
+
   `pmlc convert --input_file input/text/index.pml`
 
 ## More info

--- a/input/text/index.pml
+++ b/input/text/index.pml
@@ -160,7 +160,8 @@
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -243,7 +244,8 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -324,7 +326,8 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
                             [html
                                 <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                     <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                    <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                    <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                     <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                     <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                     <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -504,7 +507,8 @@ Text for marker
                             [html
                                 <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                     <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                    <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                    <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                     <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                     <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                     <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -607,11 +611,21 @@ Text for marker
                             [html
                                 <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                     <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>halign</td></tr>
-                                    <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>This optional parameter specifies the horizontal alignment for each column in a table.<br />The alignments are defined as a comma-separated list, in the order of the columns.<br />For each column the following values can be specified:<br />- left or l<br />- center or c<br />- right or r<br />- {empty} (default alignment (usually left-aligned) will be used)<br />The values are case-insensitive. Uppercase letters are allowed.</td></tr>
+                                    <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>This optional parameter specifies the horizontal alignment for each column in a table.
+<br />The alignments are defined as a comma-separated list, in the order of the columns.
+<br />For each column the following values can be specified:
+<br />- left or l
+<br />- center or c
+<br />- right or r
+<br />- {empty} (default alignment (usually left-aligned) will be used)
+<br />The values are case-insensitive. Uppercase letters are allowed.</td></tr>
                                     <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                     <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                     <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
-                                    <tr><td style="text-align: right; vertical-align: top;">Example:</td><td><br />halign = &quot;Left, Center, , Right&quot;<br />short from:<br />halign = &quot;L, C, , R&quot;</td></tr>
+                                    <tr><td style="text-align: right; vertical-align: top;">Example:</td><td>
+<br />halign = &quot;Left, Center, , Right&quot;
+<br />short from:
+<br />halign = &quot;L, C, , R&quot;</td></tr>
                                 </table>
                             html]
                         ]
@@ -619,7 +633,8 @@ Text for marker
                             [html
                                 <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                     <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                    <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                    <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                     <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                     <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                     <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -747,7 +762,8 @@ table_data]
                             [html
                                 <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                     <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                    <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                    <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                     <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                     <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                     <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -1398,7 +1414,8 @@ Table with 2 rows and 3 columns:
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -1473,7 +1490,8 @@ Table with 2 rows and 3 columns:
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -1546,7 +1564,8 @@ Table with 2 rows and 3 columns:
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -1679,7 +1698,8 @@ Table with 2 rows and 3 columns:
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -1759,7 +1779,8 @@ Table with 2 rows and 3 columns:
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -1828,7 +1849,8 @@ Table with 2 rows and 3 columns:
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -1956,7 +1978,8 @@ html]
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -2079,7 +2102,8 @@ html]
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -2185,7 +2209,8 @@ html]
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -2303,7 +2328,8 @@ html]
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -2401,7 +2427,8 @@ html]
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -2494,11 +2521,14 @@ j = 1;</code></pre>
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>from_regex</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>If this parameter is not defined (set to null by default) then the source code inserted into the document starts at the beginning of the file content. A regular expression can be assigned to this parameter. In that case the source code inserted into the document starts at the first match of the regular expression in the source code file.<br /><br />If parameter 'include_from_regex' is set to 'yes' (default value), then the string that matches the regex is included in the document's source code. If parameter 'include_from_regex' is set to 'no' then the string that matches the regex is not included in the document's source code.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>If this parameter is not defined (set to null by default) then the source code inserted into the document starts at the beginning of the file content. A regular expression can be assigned to this parameter. In that case the source code inserted into the document starts at the first match of the regular expression in the source code file.
+<br />
+<br />If parameter 'include_from_regex' is set to 'yes' (default value), then the string that matches the regex is included in the document's source code. If parameter 'include_from_regex' is set to 'no' then the string that matches the regex is not included in the document's source code.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>regex or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Example:</td><td>from_regex = &quot;function foo ( name string )&quot;<br />from_regex = &quot;// start insert.*\r?\n&quot; include_from_regex = no</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Example:</td><td>from_regex = &quot;function foo ( name string )&quot;
+<br />from_regex = &quot;// start insert.*\r?\n&quot; include_from_regex = no</td></tr>
                             </table>
                         html]
                     ]
@@ -2518,7 +2548,8 @@ j = 1;</code></pre>
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -2578,11 +2609,14 @@ j = 1;</code></pre>
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>to_regex</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>If this parameter is not defined (set to null by default) then the source code inserted into the document ends at the end of the file content. A regular expression can be assigned to this parameter. In that case the source code inserted into the document ends at the first match of the regular expression in the source code file. If parameter 'from_regex' is also defined, then the search for this regex starts after the match of 'from_regex'.<br /><br />If parameter 'include_to_regex' is set to 'yes' (default value), then the string that matches the regex is included in the document's source code. If parameter 'include_to_regex' is set to 'no' then the string that matches the regex is not included in the document's source code.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>If this parameter is not defined (set to null by default) then the source code inserted into the document ends at the end of the file content. A regular expression can be assigned to this parameter. In that case the source code inserted into the document ends at the first match of the regular expression in the source code file. If parameter 'from_regex' is also defined, then the search for this regex starts after the match of 'from_regex'.
+<br />
+<br />If parameter 'include_to_regex' is set to 'yes' (default value), then the string that matches the regex is included in the document's source code. If parameter 'include_to_regex' is set to 'no' then the string that matches the regex is not included in the document's source code.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>regex or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Example:</td><td>to_regex = &quot;\}\r?\n&quot;<br />to_regex = &quot;\s*// end insert&quot; include_to_regex = no</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Example:</td><td>to_regex = &quot;\}\r?\n&quot;
+<br />to_regex = &quot;\s*// end insert&quot; include_to_regex = no</td></tr>
                             </table>
                         html]
                     ]
@@ -2641,7 +2675,8 @@ function start
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>
@@ -2706,7 +2741,8 @@ input]
                         [html
                             <table border=0 cellspacing=0 cellpadding=3 style="margin-bottom:1em;">
                                 <tr><td style="text-align: right; vertical-align: top;">Id:</td><td>id</td></tr>
-                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
+                                <tr><td style="text-align: right; vertical-align: top;">Description:</td><td>A unique identifier for the node. The id can be used for cross-referencing, or for local links in the resulting HTML code.
+<br />An identifier must start with a letter and can be followed by any number of letters, digits, and underscores. Note for programmers: The regex of an identifier is: [a-zA-Z][a-zA-Z0-9_]*. Identifiers are case-sensitive. The following identifiers are all different: name, Name, and NAME.</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Type:</td><td>string or null</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Required:</td><td>no</td></tr>
                                 <tr><td style="text-align: right; vertical-align: top;">Default value:</td><td>null</td></tr>


### PR DESCRIPTION
This commit contains various improvements and fixes, as separate commits:

1. __Code Consistency Rules__:
    + Update EditorConfig rules and create a `.gitattributes` with matching settings.
    + Update `.gitignore` rules to cover common OSs' patterns.
2. __Code Consistency Fixes__:
    + Enforce code styles consistency in project sources, according to updated EidtoConfig settings, and normalize EOLs.
    + Fix `index.pml`, which was indexed using `CRLF`: now it's indexed using `LF` and normalized at checkout according to OS's native EOL.
3. __Fix and Polish `README.md`__:
    - Fix some markdown formatting issues.
    - Convert links to reference-style links, moving their definitions at the end of the document.
    - Split paragraphs into one-sentence-per-line.

-------------------------------------------------------------------------------

> **PS**: Don't forget to **merge with _rebase_** this PR! Otherwise we'll end up with a spurious merge commit in the repository, due to multiple commits being present in the PR.

<!--  -->

> **PS2**: If you haven't done so already, you should [change the repository settings] to default to **Rebase and Merge** pull requests.


<!----------------------------- REFERENCE LINKS ------------------------------>

[change the repository settings]: https://rietta.com/blog/github-merge-types/ "What's the Difference Between the 3 Github Merge Methods?"

<!-- EOF -->
